### PR TITLE
In order to use the getenv method, the library should be initialized with createUnsafeImmutable method...

### DIFF
--- a/Env.php
+++ b/Env.php
@@ -13,7 +13,7 @@ class Env
         /**
          * If you are using vulcas/phpdotenv >= 4.x.x then use below code, and comment above line.
          *
-         * $dotenv = Dotenv\Dotenv::createImmutable(FCPATH);
+         * $dotenv = Dotenv\Dotenv::createUnsafeImmutable(FCPATH);
          */
         $dotenv->load();
     }


### PR DESCRIPTION
as it is explained here https://github.com/vlucas/phpdotenv#putenv-and-getenv
we should call `createUnsafeImmutable`instead of `createImmutable` to make the env variables available using `getenv` method.